### PR TITLE
Rewrite accordion drawer

### DIFF
--- a/TBD.md
+++ b/TBD.md
@@ -9,11 +9,13 @@
 <!-- FULLSTACK -->
 
 FORGOT PASSWORD
+add google auth
 
 <!-- FRONTEND -->
 
 Too many /auth/me requests. Change layout so /auth/me only fetches on specific layoutes? /src/layouts
 add isPending to UploadFile component
+fix mobile navigation
 
 <!-- BACKEND -->
 

--- a/frontend/cheat-sheet.md
+++ b/frontend/cheat-sheet.md
@@ -1,4 +1,4 @@
-// This components functionality is to
+// This component functionality is to
 
 // ========= MODULES ==========
 import styles from "./styles/";

--- a/frontend/src/app/routes/admin/Dashboard.tsx
+++ b/frontend/src/app/routes/admin/Dashboard.tsx
@@ -6,21 +6,22 @@ import { useState } from "react";
 import styles from "./styles/Dashboard.module.scss";
 import UserList from "./UserList";
 import { Authorization, ROLES } from "@/lib/authorization";
-
+import AccordionDrawer from "@/components/UI/AccordionDrawer/AccordionDrawer";
 // ======= COMPONENTS =========
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const AdminDashboard = () => {
-  const [expanded, setExpanded] = useState<string | false>(false);
-
-  const handleChange =
+  // This state sets object with key as argument passed to handleExpandPanel
+  // and boolean as value to check if child component should be opened and content fetched
+  const [expandedPanels, setExpandedPanels] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const handleExpandPanel =
     (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
-      setExpanded(isExpanded ? panel : false);
+      setExpandedPanels((prevState) => ({
+        ...prevState,
+        [panel]: isExpanded,
+      }));
     };
-
   return (
     <Authorization
       forbiddenFallback={<div>Only admin can view this.</div>}
@@ -28,27 +29,18 @@ const AdminDashboard = () => {
     >
       <div className={styles.container}>
         <span>ADMIN DASHBOARD</span>
-        <div>
-          <Accordion
-            expanded={expanded === "panel1"}
-            onChange={handleChange("panel1")}
-            sx={{
-              boxShadow:
-                "0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 2px rgba(0, 0, 0, 0.14), 0px 1px 3px 3px rgba(0, 0, 0, 0.12)",
-            }}
-          >
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon />}
-              aria-controls="panel1-content"
-              id="panel1-header"
-            >
-              List of users
-            </AccordionSummary>
-            <AccordionDetails>
-              <UserList shouldFetch={expanded === "panel1"} />
-            </AccordionDetails>
-          </Accordion>
-        </div>
+        <AccordionDrawer
+          panelTitle="User List"
+          panelName="userPanel"
+          sx={{
+            boxShadow:
+              "0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 2px rgba(0, 0, 0, 0.14), 0px 1px 3px 3px rgba(0, 0, 0, 0.12)",
+          }}
+          expanded={!!expandedPanels["userPanel"]}
+          onChange={handleExpandPanel("userPanel")}
+        >
+          <UserList shouldFetch={!!expandedPanels["userPanel"]} />
+        </AccordionDrawer>
       </div>
     </Authorization>
   );

--- a/frontend/src/components/UI/AccordionDrawer/AccordionDrawer.tsx
+++ b/frontend/src/components/UI/AccordionDrawer/AccordionDrawer.tsx
@@ -1,0 +1,47 @@
+// This component functionality is to display custom component provided via children
+// as well as provide boolean values if its open or not to parent component
+
+// ======= COMPONENTS =========
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+interface AccordionDrawerProps {
+  panelName: string;
+  sx?: object;
+  panelTitle?: string;
+  children: React.ReactNode;
+  expanded: boolean;
+  onChange: (event: React.SyntheticEvent, isExpanded: boolean) => void;
+}
+
+const AccordionDrawer = ({
+  panelName,
+  sx,
+  panelTitle,
+  children,
+  expanded,
+  onChange,
+}: AccordionDrawerProps) => {
+  return (
+    <Accordion expanded={expanded} onChange={onChange} sx={sx}>
+      {/* the onChange event handler provides two arguments:
+      the synthetic event and a boolean indicating whether the panel is expanded or not.
+      This is how isExpanded gets its value. When you call handleExpandPanel
+      in parent component `AccordionDrawer`,
+      it returns a function that expects these two arguments. */}
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls={`${panelName}-content`}
+        id={`${panelName}-header`}
+      >
+        {`Panel ${panelTitle}`}
+      </AccordionSummary>
+      {/* children here is another component such like @/app/routes/admin/UserList */}
+      <AccordionDetails>{children}</AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default AccordionDrawer;


### PR DESCRIPTION
1. Accordion is now way more universal. Thanks to applied changes, props can now be applied to child components and there could be multiple in the current parent component (https://github.com/PatrykMajchrzakDev/StarterAppBolierplate/commit/827b678c5cf03844f443d17cc0585d58b162995a) 827b678c5cf03844f443d17cc0585d58b162995a
2.  [Rewrote admin dashboard component to match new changes made to AccorionDrawer (https://github.com/PatrykMajchrzakDev/StarterAppBolierplate/commit/747bb92600d147890b4d86a052ca6512a45505c8) 747bb92600d147890b4d86a052ca6512a45505c8
